### PR TITLE
GEODE-3195 Add querying example to the geode-examples

### DIFF
--- a/queries/README.md
+++ b/queries/README.md
@@ -1,0 +1,90 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Geode Querying Example
+
+This example demonstrates simple queries on a region.
+
+In this example, two servers host a single partitioned region with entries
+that represent employee information.
+The example does queries through the API and presents example queries
+to be invoked through the `gfsh` command-line interface.
+
+This example assumes that Java and Geode are installed.
+
+## Set up the cluster 
+1. Set directory ```geode-examples/queries``` to be the
+current working directory.
+Each step in this example specifies paths relative to that directory.
+
+2. Build the example (with the `EmployeeData` class)
+
+        $ ../gradlew build
+
+3. Run a script that starts a locator and two servers,
+and then creates the ```example-region``` region.
+
+        $ gfsh run --file=scripts/start.gfsh
+
+## Run the example program
+1. Run the example to populate `example-region` with employee information,
+print out the region information,
+and then programmatically invoke three queries,
+printing the results of each query.
+
+        $ ../gradlew run
+
+## Issue `gfsh` commands to query the region
+
+`gfsh` can also be used to issue queries.
+
+1. Start `gfsh` and connect to the cluster:
+
+        $ gfsh
+        ...
+        gfsh>connect --locator=127.0.0.1[10334]
+
+2. The quantity of entries may be observed with `gfsh`:
+
+        gfsh>describe region --name=example-region
+
+    Here are some `gfsh` queries to try on the `example-region` region.
+
+    Query for all entries in the region:
+
+        gfsh>query --query="select * from /example-region"
+
+    Query for the `email` field of all entries in the region:
+
+        gfsh>query --query="SELECT x.email FROM /example-region x"
+
+    Query for all entries that have a `lastName` field that starts
+    with the letter 'C':
+
+        gfsh>query --query="SELECT DISTINCT * FROM /example-region x WHERE x.lastName.startsWith('C')"
+
+## Shut down the cluster and clean up the directory
+1. Shut down the cluster and exit `gfsh`, answering `Y` when prompted:
+
+        gfsh>run --file=scripts/stop.gfsh
+        gfsh>exit
+
+2. Clean up the generated directories and files so that this example
+can be rerun from the step that invokes the `start.gfsh` script.
+    
+        $ ../gradlew cleanServer
+

--- a/queries/scripts/new_startAll.sh
+++ b/queries/scripts/new_startAll.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+current=`pwd`
+
+cd `dirname $0`
+
+. ./setEnv.sh
+
+cd $current
+
+#export GEODE_LOCATOR_PORT="${GEODE_LOCATOR_PORT:-10334}"
+# start a locator
+gfsh start locator --name=locator1 --mcast-port=0 --port=${GEODE_LOCATOR_PORT}
+
+# start 2 servers on a random available port
+for N in {1..2}
+do
+ gfsh start server --locators=localhost[${GEODE_LOCATOR_PORT}] --name=server$N  --server-port=0 --mcast-port=0 --classpath=${PWD}/build/libs/partitioned-1.2.0-SNAPSHOT.jar
+done
+
+# create 2 regions with the same data using GFSH, one that works well,
+#  good keys, and the other that implements a bad hashCode on the key
+gfsh -e "connect --locator=localhost[${GEODE_LOCATOR_PORT}]" -e "create region --name=EmployeeRegion --type=PARTITION"
+
+gfsh -e "connect --locator=localhost[${GEODE_LOCATOR_PORT}]" -e "create region --name=BadEmployeeRegion --type=PARTITION"
+
+gfsh -e "connect --locator=localhost[${GEODE_LOCATOR_PORT}]" -e "list members"
+
+exit 0
+

--- a/queries/scripts/start.gfsh
+++ b/queries/scripts/start.gfsh
@@ -16,12 +16,10 @@
 #
 start locator --name=locator --bind-address=127.0.0.1
 
-start server --name=server1 --locators=127.0.0.1[10334] --server-port=0
-start server --name=server2 --locators=127.0.0.1[10334] --server-port=0
+start server --name=server1 --locators=127.0.0.1[10334] --server-port=0 --classpath=../build/classes/main
+start server --name=server2 --locators=127.0.0.1[10334] --server-port=0 --classpath=../build/classes/main
 
-#connect
-
-create region --name=example-region --type=REPLICATE
+create region --name=example-region --type=PARTITION
 
 list members
 describe region --name=example-region

--- a/queries/scripts/stop.gfsh
+++ b/queries/scripts/stop.gfsh
@@ -14,14 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-start locator --name=locator --bind-address=127.0.0.1
-
-start server --name=server1 --locators=127.0.0.1[10334] --server-port=0
-start server --name=server2 --locators=127.0.0.1[10334] --server-port=0
-
-#connect
-
-create region --name=example-region --type=REPLICATE
-
-list members
-describe region --name=example-region
+connect --locator=127.0.0.1[10334]
+shutdown --include-locators=true

--- a/queries/src/main/java/org/apache/geode/examples/queries/EmployeeData.java
+++ b/queries/src/main/java/org/apache/geode/examples/queries/EmployeeData.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.examples.queries;
+
+import java.io.Serializable;
+
+public class EmployeeData implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  // private EmployeeKey nameAndNumber;
+  private String firstName;
+  private String lastName;
+  private int emplNumber;
+  private String email;
+  private int salary;
+  private int hoursPerWeek;
+
+  // public EmployeeData(EmployeeKey nameAndNumber, int salary, int hoursPerWeek) {
+  // this.nameAndNumber = nameAndNumber;
+  // this.salary = salary;
+  // this.hoursPerWeek = hoursPerWeek;
+  // }
+
+  public EmployeeData(String firstName, String lastName, int emplNumber, String email, int salary,
+      int hoursPerWeek) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.emplNumber = emplNumber;
+    this.email = email;
+    this.salary = salary;
+    this.hoursPerWeek = hoursPerWeek;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public int getEmplNumber() {
+    return emplNumber;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public int getSalary() {
+    return salary;
+  }
+
+  public int getHoursPerWeek() {
+    return hoursPerWeek;
+  }
+
+  @Override
+  // public String toString() {
+  // return "EmployeeData [nameAndNumber=" + nameAndNumber + ", salary=" + salary + ",
+  // hoursPerWeek="
+  // + hoursPerWeek + "]";
+  // }
+  public String toString() {
+    return "EmployeeData [firstName=" + firstName + ", lastName=" + lastName + ", emplNumber="
+        + emplNumber + ", email= " + email + ", salary=" + salary + ", hoursPerWeek=" + hoursPerWeek
+        + "]";
+  }
+}

--- a/queries/src/main/java/org/apache/geode/examples/queries/Example.java
+++ b/queries/src/main/java/org/apache/geode/examples/queries/Example.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.examples.queries;
+
+import java.util.function.Consumer;
+import java.util.Iterator;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.query.Query;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.SelectResults;
+
+
+public class Example implements Consumer<Region<Integer, EmployeeData>> {
+  public static void main(String[] args) {
+    // connect to the locator using default port 10334
+    ClientCache cache = new ClientCacheFactory().addPoolLocator("127.0.0.1", 10334)
+        .set("log-level", "WARN").create();
+
+    // create a local region that matches the server region
+    Region<Integer, EmployeeData> region =
+        cache.<Integer, EmployeeData>createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY)
+            .create("example-region");
+
+    Example e = new Example();
+    e.accept(region);
+    e.doQueries(cache, region);
+    cache.close();
+  }
+
+  @Override
+  public void accept(Region<Integer, EmployeeData> region) {
+    // put entries in the region
+    String[] firstNames =
+        "Alex,Bertie,Kris,Dale,Frankie,Jamie,Morgan,Pat,Ricky,Taylor,Casey,Jessie,Ryan,Skyler"
+            .split(",");
+    String[] lastNames =
+        "Able,Bell,Call,Driver,Forth,Jive,Minnow,Puts,Reliable,Tack,Catch,Jam,Redo,Skip".split(",");
+    int salaries[] = new int[] {60000, 80000, 75000, 90000, 100000};
+    int hours[] = new int[] {40, 40, 40, 40, 30, 20};
+    int emplNumber = 10000;
+    for (int index = 0; index < firstNames.length; index++) {
+      emplNumber = emplNumber + index;
+      Integer key = emplNumber;
+      String email = firstNames[index] + "." + lastNames[index] + "@example.com";
+      int salary = salaries[index % 5];
+      int hoursPerWeek = hours[index % 6];
+      EmployeeData value = new EmployeeData(firstNames[index], lastNames[index], emplNumber, email,
+          salary, hoursPerWeek);
+      region.put(key, value);
+    }
+
+    // count the values in the region
+    int inserted = region.keySetOnServer().size();
+    System.out.println(String.format("Counted %d keys in region %s", inserted, region.getName()));
+
+    // fetch and print all values in the region (without using a query)
+    region.keySetOnServer().forEach(key -> System.out.println(region.get(key)));
+
+  }
+
+  // Query using the API
+  private void doQueries(ClientCache cache, Region<Integer, EmployeeData> region) {
+    String regionName = region.getName();
+    QueryService queryService = cache.getQueryService();
+
+    // query for every entry in the region, and print query results
+    String queryString1 = "SELECT DISTINCT * FROM /" + regionName;
+    System.out.println(String.format("\nQuery: %s", queryString1));
+    Query query = queryService.newQuery(queryString1);
+    SelectResults<EmployeeData> results = null;
+    try {
+      results = (SelectResults<EmployeeData>) query.execute();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    Iterator<EmployeeData> i = results.iterator();
+    while (i.hasNext()) {
+      System.out.println(String.format("Employee: %s", i.next().toString()));
+    }
+
+    // query for all part time employees, and print query results
+    String queryString2 = "SELECT DISTINCT * FROM /" + regionName + " h WHERE h.hoursPerWeek < 40";
+    System.out.println(String.format("\nQuery: %s", queryString2));
+    query = queryService.newQuery(queryString2);
+    results = null;
+    try {
+      results = (SelectResults<EmployeeData>) query.execute();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    i = results.iterator();
+    while (i.hasNext()) {
+      System.out.println(String.format("Employee: %s", i.next().toString()));
+    }
+
+    // query for last name of Jive, and print the full name and employee number
+    String queryString3 = "SELECT DISTINCT * FROM /" + regionName + " x WHERE x.lastName='Jive'";
+    System.out.println(String.format("\nQuery: %s", queryString3));
+    query = queryService.newQuery(queryString3);
+    results = null;
+    try {
+      results = (SelectResults<EmployeeData>) query.execute();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    i = results.iterator();
+    while (i.hasNext()) {
+      EmployeeData empl = i.next();
+      System.out.println(String.format("Employee %s %s has employee number %d", empl.getFirstName(),
+          empl.getLastName(), empl.getEmplNumber()));
+    }
+  }
+}

--- a/queries/src/test/java/org/apache/geode/examples/queries/ExampleTest.java
+++ b/queries/src/test/java/org/apache/geode/examples/queries/ExampleTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.examples.queries;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.geode.cache.Region;
+import org.geode.examples.util.Mocks;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemOutRule;
+
+public class ExampleTest {
+
+  @Rule
+  public SystemOutRule systemOutRule = new SystemOutRule().enableLog();
+
+  @Test
+  public void testExample() throws Exception {
+    Region<Integer, EmployeeData> region = Mocks.region("example-region");
+    new Example().accept(region);
+
+    assertThat(systemOutRule.getLog()).contains("Counted 14 keys in region");
+    assertThat(systemOutRule.getLog()).contains("Jamie");
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,4 +18,5 @@ rootProject.name = 'geode-examples'
 
 include 'replicated'
 include 'partitioned'
+include 'queries'
 include 'loader'


### PR DESCRIPTION
Here is a new geode-example that presents very simple queries on a single region done 2 ways: API calls and issued via gfsh.  My goal was to keep this example as simple as possible, focusing on demonstrating an introduction to queries. Please review.

Note: I tested this example using Geode built-from-source from the release/1.2.0 branch. 