### PR TITLE
Use the geode nightly snapshots for the develop branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,56 +21,38 @@ plugins {
   id "de.undercouch.download" version "3.1.2"
 }
 
-def downloadUrl = (geodeReleaseUrl != "") ? geodeReleaseUrl :
-    "https://www.apache.org/dyn/closer.cgi?action=download&filename=geode/$geodeVersion"
-def verificationUrl = (geodeReleaseUrl != "") ? geodeReleaseUrl :
-    "https://www.apache.org/dist/geode/$geodeVersion"
-
-def downloadFile = "apache-geode-${geodeVersion}.tar.gz"
-def installFile = "$buildDir/$downloadFile"
-def installDir = "$buildDir/apache-geode-${geodeVersion}"
-
-task downloadGeode {
-  inputs.property 'geodeVersion', geodeVersion
-  outputs.file installFile
-  outputs.file "${installFile}.sha256"
-
-  doLast {
-    download {
-      src([
-        "$downloadUrl/$downloadFile",
-        "$verificationUrl/${downloadFile}.sha256"
-      ])
-      dest buildDir
+allprojects {
+  repositories {
+    if (geodeRepositoryUrl != "") {
+      maven {
+        url geodeRepositoryUrl
+      }
+    }
+    mavenCentral()
+    maven {
+      url 'http://repository.apache.org/snapshots'
     }
   }
 }
 
-task verifyGeode(type: de.undercouch.gradle.tasks.download.Verify, dependsOn: downloadGeode) {
-  src installFile
-  algorithm "SHA-256"
-  doFirst {
-    checksum file("${installFile}.sha256").text.split(' ')[0]
-  }
+def installDir = "$buildDir/apache-geode-${geodeVersion}"
+
+configurations {
+  geodeDistribution
 }
 
-task installGeode(type: Copy, dependsOn: verifyGeode) {
-  inputs.file installFile
-  outputs.dir installDir
+dependencies {
+  geodeDistribution "org.apache.geode:apache-geode:$geodeVersion"
+}
 
-  from tarTree(resources.gzip(installFile))
+task installGeode(type: Copy) {
+  from zipTree(configurations.geodeDistribution.singleFile)
   into buildDir
 }
 
 allprojects {
   apply plugin:'java'
 
-  repositories {
-    if (geodeRepositoryUrl != "") {
-      maven { url geodeRepositoryUrl }
-    }
-    mavenCentral()
-  }
 
   dependencies {
     compile "org.apache.geode:geode-core:$geodeVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 version = 1.4.0-SNAPSHOT
-geodeVersion = 1.2.1
+geodeVersion = 1.4.0-SNAPSHOT
 
 # release properties, set these on the command line to validate against
 # a release candidate


### PR DESCRIPTION
In order to write examples for the current code, the geode-examples
develop branch should point to the geode nightly snapshots.

master should remain pointed to the latest release, and that is what users
will get when they clone.

Also, changing the download to use the version of geode from maven.