### PR TITLE
Only apply the java plugin to subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,9 +50,8 @@ task installGeode(type: Copy) {
   into buildDir
 }
 
-allprojects {
+subprojects {
   apply plugin:'java'
-
 
   dependencies {
     compile "org.apache.geode:geode-core:$geodeVersion"
@@ -62,30 +61,8 @@ allprojects {
     testCompile "org.mockito:mockito-core:$mockitocoreVersion"
     testCompile "com.github.stefanbirkner:system-rules:$systemrulesVersion"
     testCompile "org.assertj:assertj-core:$assertjVersion"
-  }
-}
-
-configurations {
-  testArchives
-}
-
-dependencies {
-  testArchives sourceSets.test.output
-}
-
-subprojects {
-  dependencies {
     compile "org.apache.logging.log4j:log4j-core:$log4jVersion"
     runtime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
-    testCompile project(path: ':', configuration: 'testArchives')
-  }
-
-  jar {
-    archiveName "${baseName}.${extension}"
-  }
-
-  jar {
-    archiveName "${baseName}.${extension}"
   }
 
   jar {

--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-allprojects {
+subprojects {
   apply plugin: 'eclipse'
   eclipse {
     classpath {


### PR DESCRIPTION
Now that we have no shared test code for the examples, we don't really
need the top level project to be a java project.