### PR TITLE
Removing calls to destroy region in scripts

### DIFF
--- a/async/scripts/stop.gfsh
+++ b/async/scripts/stop.gfsh
@@ -16,7 +16,5 @@
 #
 
 connect --locator=127.0.0.1[10334]
-destroy region --name=outgoing-region
-destroy region --name=incoming-region
 undeploy --jar=build/libs/async.jar
 shutdown --include-locators=true

--- a/functions/scripts/stop.gfsh
+++ b/functions/scripts/stop.gfsh
@@ -16,5 +16,4 @@
 #
 
 connect --locator=127.0.0.1[10334]
-destroy region --name=example-region
 shutdown --include-locators=true

--- a/writer/scripts/stop.gfsh
+++ b/writer/scripts/stop.gfsh
@@ -16,5 +16,4 @@
 #
 
 connect --locator=127.0.0.1[10334]
-destroy region --name=example-region
 shutdown --include-locators=true


### PR DESCRIPTION
We seem to have an issue where the destroy region is failing in travis.
Removing to fix the flakiness in the build for now.

@PivotalSarge 