### PR TITLE
GEODE-4646: Add build-specific instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,14 +114,17 @@ Follow this approach to add a new example:
 * Create a Java class with a main method in the `org.apache.geode_examples.$name.Example` class
 * Create a cluster initialization script in `scripts/start.gfsh`
 * Create a cluster shutdown script in `scripts/stop.gfsh`
+* Modify the top-level `settings.gradle` file to include subproject
+* Modify this `README.md` file to include the new example in the catalog of examples
 
 The scripts should contain `gfsh` commands for starting locators, servers, and
 creating regions--everything that the example program will need to use. Where
 appropriate you should also add unit tests. To customize the build you can add
 a `build.gradle` file.
 
+Verify that the examples build by executing `./gradle runAll` from the root directory.
 Note that the build may fail if you do not add ASF license headers or use the
-correct formatting (you can fix formatting with `gradle spotlessApply`).
+correct formatting. (You can fix formatting with `gradle spotlessApply`.)
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ The gradle build will automatically download and install a Geode release in the
 The commands you need to invoke will be given in the `README.md` file. Sample
 usage:
 
-    $ ./gradle :replicated:start
-    $ ./gradle :replicated:run
-    $ ./gradle :replicated:stop
-    $ ./gradle runAll
+    $ ./gradlew :replicated:start
+    $ ./gradlew :replicated:run
+    $ ./gradlew :replicated:stop
+    $ ./gradlew runAll
 
 ## Catalog of examples
 
@@ -122,9 +122,9 @@ creating regions--everything that the example program will need to use. Where
 appropriate you should also add unit tests. To customize the build you can add
 a `build.gradle` file.
 
-Verify that the examples build by executing `./gradle runAll` from the root directory.
+Verify that the examples build by executing `./gradlew runAll` from the root directory.
 Note that the build may fail if you do not add ASF license headers or use the
-correct formatting. (You can fix formatting with `gradle spotlessApply`.)
+correct formatting. You can fix formatting with `./gradlew spotlessApply`.
 
 ## References
 


### PR DESCRIPTION
Add text about modifying `settings.gradle` and `README.md` and verifying that everything still builds.