### PR TITLE
GEODE-4666: Ensure clean working environments when running examples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,9 +99,51 @@ subprojects {
     main = "org.apache.geode_examples.${project.name}.Example"
   }
 
-  task runAll(dependsOn: [start, run, stop])
+  task waitForExitingMembers(type: Exec) {
+    workingDir projectDir
+    environment 'GEODE_HOME', installDir
+    environment 'PATH', geodePath
+    ignoreExitValue true
+    commandLine 'sh', '-c', "" +
+            "TIMEOUT=10 ;" +
+            "echo \"Waiting at most \$TIMEOUT seconds for all members to shut down...\" ;" +
+            "while pgrep -f \"(Server|Locator)Launcher\" > /dev/null ; do  printf \".\" ; " +
+            "  sleep 1 ;" +
+            "  TIMEOUT=\$((\$TIMEOUT - 1)) ;" +
+            "  if [[ \$TIMEOUT -eq 0 ]] ; then" +
+            "    echo \"\" ;" +
+            "    exit 10 ;" +
+            "  fi ;" +
+            "done ;" +
+            "echo \"\""
+    doLast {
+      // We use exit code 10 to avoid conflict with pgrep exit codes.
+      if (execResult.exitValue == 10) {
+        throw new GradleException("A member process persisted beyond permitted timeout.  Aborting.")
+      } else if (execResult.exitValue != 0) {
+        throw new GradleException("waitForExistingMembers failed with exit code: " + execResult.exitValue)
+      }
+    }
+  }
+
+  task verifyNoMembersRunning(type: Exec) {
+    workingDir projectDir
+    environment 'GEODE_HOME', installDir
+    environment 'PATH', geodePath
+    ignoreExitValue true
+    commandLine 'sh', '-c', "pgrep -f \"(Server|Locator)Launcher\" > /dev/null ; "
+    doLast {
+      if (execResult.exitValue == 0) {
+        throw new GradleException("Existing members detected.  Examples expect a clean environment in which to run.")
+      }
+    }
+  }
+
+  task runAll(dependsOn: [verifyNoMembersRunning, start, run, stop, waitForExitingMembers])
+  start.mustRunAfter verifyNoMembersRunning
   run.mustRunAfter start
   stop.mustRunAfter run
+  waitForExitingMembers.mustRunAfter stop
 }
 
 apply from: "gradle/spotless.gradle"


### PR DESCRIPTION
Added tasks `verifyNoMembersRunning` and `waitForExitingMembers` to ensure a clean environment in which to run examples, executing before and after each example (respectively) performed by the `runAll` task.  `waitForExitingMembers` waits at most 10 seconds before failing.

These tasks are *not* executed when tasks `start` or `stop` are invoked directly, presuming a more active involvement from the user, although they could be easily added if that is preferred.