### PR TITLE
Alternative GEODE-4666: use single-bracket comparisons

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,8 @@ subprojects {
     commandLine 'sh', '-c', "" +
             "TIMEOUT=10 ;" +
             "echo \"Waiting at most \$TIMEOUT seconds for all members to shut down...\" ;" +
-            "while pgrep -f \"(Server|Locator)Launcher\" > /dev/null ; do  printf \".\" ; " +
+            "while pgrep -f \"(Server|Locator)Launcher\" > /dev/null ; do" +
+            "  echo \"Waiting at most \${TIMEOUT} seconds...\" ; " +
             "  sleep 1 ;" +
             "  TIMEOUT=\$((\$TIMEOUT - 1)) ;" +
             "  if [ \$TIMEOUT -eq 0 ] ; then" +

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ subprojects {
     commandLine 'sh', '-c', "" +
             "TIMEOUT=120 ;" +
             "echo \"Waiting at most \$TIMEOUT seconds for all members to shut down...\" ;" +
-            "while pgrep -f \"(Server|Locator)Launcher\" ; do" +
+            "while pgrep -f \"(Server|Locator)Launcher\" > /dev/null ; do" +
             "  printf \".\" ; " +
             "  sleep 1 ;" +
             "  TIMEOUT=\$((\$TIMEOUT - 1)) ;" +

--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ subprojects {
     environment 'PATH', geodePath
     ignoreExitValue true
     commandLine 'sh', '-c', "" +
-            "TIMEOUT=20 ;" +
+            "TIMEOUT=120 ;" +
             "echo \"Waiting at most \$TIMEOUT seconds for all members to shut down...\" ;" +
             "while pgrep -f \"(Server|Locator)Launcher\" > /dev/null ; do" +
             "  printf \".\" ; " +

--- a/build.gradle
+++ b/build.gradle
@@ -107,7 +107,7 @@ subprojects {
     commandLine 'sh', '-c', "" +
             "TIMEOUT=120 ;" +
             "echo \"Waiting at most \$TIMEOUT seconds for all members to shut down...\" ;" +
-            "while pgrep -f \"(Server|Locator)Launcher\" > /dev/null ; do" +
+            "while pgrep -f \"(Server|Locator)Launcher\" ; do" +
             "  printf \".\" ; " +
             "  sleep 1 ;" +
             "  TIMEOUT=\$((\$TIMEOUT - 1)) ;" +

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ subprojects {
             "while pgrep -f \"(Server|Locator)Launcher\" > /dev/null ; do  printf \".\" ; " +
             "  sleep 1 ;" +
             "  TIMEOUT=\$((\$TIMEOUT - 1)) ;" +
-            "  if [[ \$TIMEOUT -eq 0 ]] ; then" +
+            "  if [ \$TIMEOUT -eq 0 ] ; then" +
             "    echo \"\" ;" +
             "    exit 10 ;" +
             "  fi ;" +

--- a/build.gradle
+++ b/build.gradle
@@ -105,10 +105,10 @@ subprojects {
     environment 'PATH', geodePath
     ignoreExitValue true
     commandLine 'sh', '-c', "" +
-            "TIMEOUT=10 ;" +
+            "TIMEOUT=20 ;" +
             "echo \"Waiting at most \$TIMEOUT seconds for all members to shut down...\" ;" +
             "while pgrep -f \"(Server|Locator)Launcher\" > /dev/null ; do" +
-            "  echo \"Waiting at most \${TIMEOUT} seconds...\" ; " +
+            "  printf \".\" ; " +
             "  sleep 1 ;" +
             "  TIMEOUT=\$((\$TIMEOUT - 1)) ;" +
             "  if [ \$TIMEOUT -eq 0 ] ; then" +

--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,8 @@ subprojects {
     environment 'GEODE_HOME', installDir
     environment 'PATH', geodePath
     ignoreExitValue true
-    commandLine 'sh', '-c', "pgrep -f \"(Server|Locator)Launcher\" > /dev/null ; "
+    commandLine 'sh', '-c', "echo \"Looking for existing member processes...\" ; " +
+            "pgrep -f \"(Server|Locator)Launcher\" ; "
     doLast {
       if (execResult.exitValue == 0) {
         throw new GradleException("Existing members detected.  Examples expect a clean environment in which to run.")


### PR DESCRIPTION
I was trying to get Travis to complain, and boy have I ever.

Single-bracket comparison seem good (although I don't know about the CI pipeline...).  Although I though @PivotalSarge said it would break for him on his machine?  Got a stack for how this PR builds for you?

The two Travis failures look like the `async` example is actually failing to shut down, but at least the output isn't full of `.sh: 1: [[ unknown`.