### PR TITLE
GEODE-6060: Properly registering example cache listener

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Geode Examples
-Copyright 2017 The Apache Software Foundation.
+Copyright 2017-2018 The Apache Software Foundation.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version = 1.7.0
-geodeVersion = 1.7.0
+version = 1.8.0-SNAPSHOT
+geodeVersion = 1.8.0-SNAPSHOT
 
 # release properties, set these on the command line to validate against
 # a release candidate

--- a/listener/src/main/java/org/apache/geode_examples/listener/Example.java
+++ b/listener/src/main/java/org/apache/geode_examples/listener/Example.java
@@ -44,6 +44,7 @@ public class Example {
     // create a local region that matches the server region
     ClientRegionFactory<Integer, String> clientRegionFactory =
         cache.createClientRegionFactory(ClientRegionShortcut.PROXY);
+    clientRegionFactory.addCacheListener(new ExampleCacheListener());
     Region<Integer, String> region = clientRegionFactory.create("example-region");
 
     example.putEntries(region);


### PR DESCRIPTION
The CacheListener example does not actually register the ExampleCacheListener() so the callback methods are not invoked which print to the console.