### PR TITLE
GEODE-6060: Properly registering example cache listener

### DIFF
--- a/listener/src/main/java/org/apache/geode_examples/listener/Example.java
+++ b/listener/src/main/java/org/apache/geode_examples/listener/Example.java
@@ -44,6 +44,7 @@ public class Example {
     // create a local region that matches the server region
     ClientRegionFactory<Integer, String> clientRegionFactory =
         cache.createClientRegionFactory(ClientRegionShortcut.PROXY);
+    clientRegionFactory.addCacheListener(new ExampleCacheListener());
     Region<Integer, String> region = clientRegionFactory.create("example-region");
 
     example.putEntries(region);


### PR DESCRIPTION
The CacheListener example does not actually register the ExampleCacheListener() so the callback methods are not invoked which print to the console.