### PR TITLE
Geode-6120/missing commons lang package

### DIFF
--- a/clientSecurity/src/main/java/org/apache/geode_examples/clientSecurity/Example.java
+++ b/clientSecurity/src/main/java/org/apache/geode_examples/clientSecurity/Example.java
@@ -16,7 +16,7 @@ package org.apache.geode_examples.clientSecurity;
 
 import java.util.Properties;
 
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.cache.Region;


### PR DESCRIPTION
The examples repo has been making use of the apache.commons-lang package
provided by the main Geode repo. In version 3 of commons-lang the
package was renamed to "commons-lang3". Since Geode updated its
dependency to that version we need to use the same package name in our
examples.