### PR TITLE
GEODE-6175: Add Jigsaw modules example.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ plugins {
     id "org.nosphere.apache.rat" version "0.3.0"
     id "com.diffplug.gradle.spotless" version "3.0.0"
     id "de.undercouch.download" version "3.1.2"
+    id 'application'
 }
 
 allprojects {
@@ -53,6 +54,7 @@ task installGeode(type: Copy) {
 
 subprojects {
     apply plugin: 'java'
+    apply plugin: 'application'
 
     dependencies {
         compile "org.apache.geode:geode-core:$geodeVersion"
@@ -102,11 +104,7 @@ subprojects {
         commandLine 'sh', '-c', "gfsh run --file=${projectDir}/scripts/stop.gfsh"
     }
 
-    task run(type: JavaExec, dependsOn: build) {
-        description = 'Run example'
-        classpath = sourceSets.main.runtimeClasspath
-        main = "org.apache.geode_examples.${project.name}.Example"
-    }
+    mainClassName = "org.apache.geode_examples.${project.name}.Example"
 
     task waitForExitingMembers(type: Exec) {
         workingDir projectDir

--- a/jigsaw/README.md
+++ b/jigsaw/README.md
@@ -1,0 +1,25 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+[<img src="https://geode.apache.org/img/apache_geode_logo.png" align="center"/>](http://geode.apache.org)
+
+[![Build Status](https://travis-ci.org.apache.geode_examples.svg?branch=develop)](https://travis-ci.org.apache.geode_examples) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+
+# Apache Geode Jigsaw examples
+
+This subproject is a continuation of the Geode Examples, specifically
+focusing on the use of ``Jigsaw'' modules introduced by Java 9.

--- a/jigsaw/cq/README.md
+++ b/jigsaw/cq/README.md
@@ -1,0 +1,29 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Geode with Jigsaw Continuous Query Example
+
+This example is a duplicate of the `geode-examples/cq` example,
+excepting that this example uses the "Jigsaw" modules introduced by Java9.
+
+See the aforementioned example's `README.md` for more information.
+
+The intent of this example is to demonstrate how to configure a simple `module-info.java` to require
+Geode (and bug-related transitive requirements of Log4j and SQL) and the configuration within
+the `build.gradle`.
+
+Note that some dependencies are injected from the root project's `build.gradle`.

--- a/jigsaw/cq/build.gradle
+++ b/jigsaw/cq/build.gradle
@@ -15,29 +15,35 @@
  * limitations under the License.
  */
 
-rootProject.name = 'geode-examples'
-
-include 'replicated'
-include 'partitioned'
-include 'queries'
-include 'lucene'
-include 'loader'
-include 'putall'
-include 'cq'
-include 'clientSecurity'
-include 'functions'
-include 'persistence'
-include 'writer'
-include 'listener'
-include 'async'
-include 'luceneSpatial'
-include 'eviction'
-include 'serialization'
-include 'expiration'
-include 'indexes'
-include 'transaction'
-include 'wan'
-
-if (JavaVersion.current().java9Compatible) {
-  include 'jigsaw:cq'
+plugins {
+  id 'java'
+  id 'org.gradle.java.experimental-jigsaw' version '0.1.1'
+  id "io.spring.dependency-management" version "1.0.6.RELEASE"
 }
+
+group 'com.example'
+version '1.0-SNAPSHOT'
+
+sourceCompatibility = 9
+targetCompatibility = 9
+
+repositories {
+  mavenLocal()
+  mavenCentral()
+  maven {
+    url 'http://maven.apachegeode-ci.info/snapshots'
+  }
+}
+
+dependencyManagement {
+  imports {
+    mavenBom "org.apache.geode:geode-client-bom:${geodeVersion}"
+  }
+}
+
+dependencies {
+  implementation 'org.apache.geode:geode-core'
+  implementation 'org.apache.geode:geode-cq'
+}
+
+javaModule.name = 'org.apache.geode_examples.cq'

--- a/jigsaw/cq/scripts/start.gfsh
+++ b/jigsaw/cq/scripts/start.gfsh
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+start locator --name=locator --bind-address=127.0.0.1
+start server --name=server1 --locators=127.0.0.1[10334] --server-port=0 --classpath=../build/classes/java/main
+start server --name=server2 --locators=127.0.0.1[10334] --server-port=0 --classpath=../build/classes/java/main
+list members
+
+create region --name=example-region --type=REPLICATE
+describe region --name=example-region

--- a/jigsaw/cq/scripts/stop.gfsh
+++ b/jigsaw/cq/scripts/stop.gfsh
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+connect --locator=127.0.0.1[10334]
+shutdown --include-locators=true

--- a/jigsaw/cq/src/main/java/module-info.java
+++ b/jigsaw/cq/src/main/java/module-info.java
@@ -15,29 +15,12 @@
  * limitations under the License.
  */
 
-rootProject.name = 'geode-examples'
+module org.apache.geode_examples.cq {
+  requires org.apache.geode.core;
 
-include 'replicated'
-include 'partitioned'
-include 'queries'
-include 'lucene'
-include 'loader'
-include 'putall'
-include 'cq'
-include 'clientSecurity'
-include 'functions'
-include 'persistence'
-include 'writer'
-include 'listener'
-include 'async'
-include 'luceneSpatial'
-include 'eviction'
-include 'serialization'
-include 'expiration'
-include 'indexes'
-include 'transaction'
-include 'wan'
+  requires com.google.common;
 
-if (JavaVersion.current().java9Compatible) {
-  include 'jigsaw:cq'
+  // These aren't necessary if we add module-info.java to geode modules.
+  requires org.apache.logging.log4j;
+  requires java.sql;
 }

--- a/jigsaw/cq/src/main/java/org/apache/geode_examples/cq/Example.java
+++ b/jigsaw/cq/src/main/java/org/apache/geode_examples/cq/Example.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode_examples.cq;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.query.*;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.base.Stopwatch;
+
+
+
+public class Example {
+
+  private ClientCache cache;
+  private Region<Integer, Integer> region;
+  private CqQuery randomTracker;
+
+  private void init() throws CqException, RegionNotFoundException, CqExistsException {
+    // init cache, region, and CQ
+
+    // connect to the locator using default port 10334
+    this.cache = connectToLocallyRunningGeode();
+
+
+    // create a local region that matches the server region
+    this.region = cache.<Integer, Integer>createClientRegionFactory(ClientRegionShortcut.PROXY)
+        .create("example-region");
+
+    this.randomTracker = this.startCQ(this.cache, this.region);
+  }
+
+  private void run() throws InterruptedException {
+
+    this.startPuttingData(this.region);
+
+  }
+
+  private void close() throws CqException {
+
+    // close the CQ and Cache
+    this.randomTracker.close();
+    this.cache.close();
+
+  }
+
+
+  public static void main(String[] args) throws Exception {
+
+    Example mExample = new Example();
+
+    mExample.init();
+
+    mExample.run();
+
+    mExample.close();
+
+    System.out.println("\n---- So that is CQ's----\n");
+
+  }
+
+  private CqQuery startCQ(ClientCache cache, Region region)
+      throws CqException, RegionNotFoundException, CqExistsException {
+    // Get cache and queryService - refs to local cache and QueryService
+
+    CqAttributesFactory cqf = new CqAttributesFactory();
+    cqf.addCqListener(new RandomEventListener());
+    CqAttributes cqa = cqf.create();
+
+    String cqName = "randomTracker";
+
+    String queryStr = "SELECT * FROM /example-region i where i > 70";
+
+    QueryService queryService = region.getRegionService().getQueryService();
+    CqQuery randomTracker = queryService.newCq(cqName, queryStr, cqa);
+    randomTracker.execute();
+
+
+    System.out.println("------- CQ is running\n");
+
+    return randomTracker;
+  }
+
+  private void startPuttingData(Region region) throws InterruptedException {
+
+    // Example will run for 20 second
+
+    Stopwatch stopWatch = Stopwatch.createStarted();
+
+    while (stopWatch.elapsed(TimeUnit.SECONDS) < 20) {
+
+      // 500ms delay to make this easier to follow
+      Thread.sleep(500);
+      int randomKey = ThreadLocalRandom.current().nextInt(0, 99 + 1);
+      int randomValue = ThreadLocalRandom.current().nextInt(0, 100 + 1);
+      region.put(randomKey, randomValue);
+      System.out.println("Key: " + randomKey + "     Value: " + randomValue);
+
+    }
+
+    stopWatch.stop();
+
+  }
+
+  private ClientCache connectToLocallyRunningGeode() {
+
+    ClientCache cache = new ClientCacheFactory().addPoolLocator("127.0.0.1", 10334)
+        .setPoolSubscriptionEnabled(true).set("log-level", "WARN").create();
+
+    return cache;
+  }
+
+}

--- a/jigsaw/cq/src/main/java/org/apache/geode_examples/cq/RandomEventListener.java
+++ b/jigsaw/cq/src/main/java/org/apache/geode_examples/cq/RandomEventListener.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode_examples.cq;
+
+import org.apache.geode.cache.Operation;
+import org.apache.geode.cache.query.CqEvent;
+import org.apache.geode.cache.query.CqListener;
+
+public class RandomEventListener implements CqListener {
+
+  @Override
+  public void onEvent(CqEvent cqEvent) {
+
+    Operation queryOperation = cqEvent.getQueryOperation();
+
+
+    if (queryOperation.isUpdate()) {
+      System.out.print("-------Updated Value\n");
+    } else if (queryOperation.isCreate()) {
+      System.out.print("-------Value Created\n");
+    }
+  }
+
+  @Override
+  public void onError(CqEvent cqEvent) {
+    System.out.print("**Something bad happened**");
+  }
+
+  @Override
+  public void close() {
+
+  }
+}


### PR DESCRIPTION
* Replace homemade 'run' task with 'application' plugin
* Create 'jigsaw' directory to contain any other similar examples.
* Copy <examples>/cq example to <examples>/jigsaw/

Co-authored-by: Patrick Rhomberg <prhomberg@pivotal.io>
Co-authored-by: Jacob Barrett <jbarrett@pivotal.io>