### PR TITLE
GEODE-6463: Use https://storage.googleapis.com for maven snapshots

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ allprojects {
         }
         mavenCentral()
         maven {
-            url 'http://maven.apachegeode-ci.info/snapshots'
+            url 'https://storage.googleapis.com/maven.apachegeode-ci.info/snapshots'
         }
     }
 }


### PR DESCRIPTION
Point directly at the gcloud bucket for nightly snapshots of geode.