### PR TITLE
Use openjdk for travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 script: ./gradlew runAll
 


### PR DESCRIPTION
Changing the jdk for travis to use to be openjdk, rather than oraclejdk. Travis seems to be having trouble installing oracle jdk on xenial.