### PR TITLE
Allow custom geode integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,8 +42,11 @@ configurations {
 }
 
 dependencies {
-    geodeDistribution "org.apache.geode:apache-geode:$geodeVersion@tgz"
-
+    geodeDistribution("org.apache.geode:apache-geode:$geodeVersion@tgz") {
+      if (gradle.usingGeodeCompositeBuild) {
+        targetConfiguration = 'compositeTarget'
+      }
+    }
 }
 
 task installGeode(type: Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 }
 
 task installGeode(type: Copy) {
+    if (gradle.usingGeodeCompositeBuild) {
+        dependsOn(gradle.includedBuild('geode').task(':geode-assembly:distTar'))
+    }
     from tarTree(configurations.geodeDistribution.singleFile)
     into buildDir
 }
@@ -150,6 +153,12 @@ subprojects {
             if (execResult.exitValue == 0) {
                 throw new GradleException("Existing members detected.  Examples expect a clean environment in which to run.")
             }
+        }
+    }
+    if (gradle.usingGeodeCompositeBuild) {
+        tasks.withType(JavaCompile) {
+            options.fork = true
+            options.forkOptions.jvmArgs += ['-Xmx3g']
         }
     }
 

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -63,6 +63,7 @@ distributions {
         exclude 'KEYS'
         exclude '**/.gradle'
         exclude '**/build/**'
+        exclude '**/out/**'
         exclude '**/.project'
         exclude '**/.classpath'
         exclude '**/.settings/**'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-all.zip

--- a/settings.gradle
+++ b/settings.gradle
@@ -39,3 +39,25 @@ include 'transaction'
 include 'wan'
 include 'jdbc'
 include 'sessionState'
+
+// Logic for defining a custom Geode clone for integration with this project
+// Define `-PgeodeCompositeDirectory` to your geode root, default `../geode`
+// Define `-Dcomposite` to enable Gradle includeBuild feature
+def geodeCompositePropertyName = 'geodeCompositeDirectory'
+def geodePath = hasProperty(geodeCompositePropertyName) ? geodeCompositeDirectory : '../geode'
+def geodeDirectory = file(geodePath).absolutePath
+def geodeDirectoryExists = file(geodeDirectory).exists()
+def compositeBuildEnabled = System.getProperty("composite") != null
+gradle.ext.usingGeodeCompositeBuild = compositeBuildEnabled && geodeDirectoryExists
+
+if (gradle.ext.usingGeodeCompositeBuild) {
+  includeBuild(geodeDirectory) {
+    it.dependencySubstitution {
+      // Any submodule used by examples must should be listed here
+      it.substitute it.module("org.apache.geode:geode-cq") with it.project(':geode-cq')
+      it.substitute it.module("org.apache.geode:geode-core") with it.project(':geode-core')
+      it.substitute it.module("org.apache.geode:apache-geode") with it.project(':geode-assembly')
+    }
+  }
+}
+


### PR DESCRIPTION
Building examples has required a published Geode tgz and jars. Use
Gradle's includeBuild feature to allow mapping to a custom Geode clone
for integration and API testing. Invoke with:
./gradlew -Dcomposite -PgeodeCompositeDirectory=../geode build

Once more, with feeling. Re-submitting this PR against `develop` instead of `master`