### PR TITLE
GEODE-6532: Dependency changes to examples related to the Geode fix.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,21 +58,25 @@ task installGeode(type: Copy) {
 }
 
 subprojects {
-    apply plugin: 'java'
+    apply plugin: 'java-library'
 
     dependencies {
-        compile "org.apache.geode:geode-core:$geodeVersion"
-        compile "org.apache.geode:geode-cq:$geodeVersion"
-        compile "org.apache.geode:geode-logging:$geodeVersion"
-        compile 'com.google.guava:guava:25.1-jre'
+        api(platform("org.apache.geode:geode-all-bom:$geodeVersion"))
+        implementation("org.apache.geode:geode-core")
+        implementation("org.apache.geode:geode-cq")
+        implementation("org.apache.geode:geode-logging")
+        implementation('com.google.guava:guava')
+        implementation('org.apache.commons:commons-lang3')
+        implementation("org.apache.logging.log4j:log4j-core")
 
-        testCompile "com.jayway.awaitility:awaitility:$awaitilityVersion"
-        testCompile "junit:junit:$junitVersion"
-        testCompile "org.mockito:mockito-core:$mockitocoreVersion"
-        testCompile "com.github.stefanbirkner:system-rules:$systemrulesVersion"
-        testCompile "org.assertj:assertj-core:$assertjVersion"
-        compile "org.apache.logging.log4j:log4j-core:$log4jVersion"
-        runtime "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
+        testImplementation("org.awaitility:awaitility")
+        testImplementation("junit:junit")
+        testImplementation("org.mockito:mockito-core")
+        testImplementation("com.github.stefanbirkner:system-rules")
+        testImplementation("org.assertj:assertj-core")
+        testImplementation('org.apache.httpcomponents:httpcore')
+        testImplementation('org.apache.httpcomponents:httpclient')
+        runtimeOnly "org.apache.logging.log4j:log4j-slf4j-impl"
     }
 
     jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,11 +22,5 @@ geodeVersion = 1.11.0-SNAPSHOT
 geodeRepositoryUrl =
 geodeReleaseUrl =
 
-# dependency versions
-assertjVersion = 3.6.2
-awaitilityVersion = 1.7.0
-junitVersion = 4.12
-mockitocoreVersion = 2.19.1
-log4jVersion = 2.11.0
-systemrulesVersion = 1.16.1
-micrometerVersion = 1.2.0
+# dependency versions not found in geode-all-bom
+micrometerVersion = 1.2.1


### PR DESCRIPTION
Several transitive dependencies will be marked 'runtime' not 'compile'
in the POM from geode, causing examples to not miss symbols. Declare
those dependencies outright.