### PR TITLE
GEODE:8757: allow travis ci to build geode examples with java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@
 language: java
 
 jdk:
-  - openjdk8
+  - openjdk11
 
 script: ./gradlew runAll
 


### PR DESCRIPTION
@upthewaterspout Kindly review if changes are ok. Then we can merge other pending pull requests afterwards.