### PR TITLE
Restore Apache Geode graphic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-[<img src="https://geode.apache.org/img/apache_geode_logo.png" align="center"/>](http://geode.apache.org)
+[<img src="https://geode.apache.org/img/Apache_Geode_logo.png" align="center"/>](http://geode.apache.org)
 
 [![Build Status](https://api.travis-ci.org/apache/geode-examples.svg?branch=develop)](https://travis-ci.org.apache.geode_examples) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
@@ -59,7 +59,7 @@ usage:
 The following sections call out ready-made examples or new examples that could
 be built. You may want to start your journey with the [Apache Geode in 15
 minutes or
-Less](http://geode.apache.org/docs/guide/13/getting_started/15_minute_quickstart_gfsh.html)
+Less](https://geode.apache.org/docs/guide/13/getting_started/15_minute_quickstart_gfsh.html)
 tutorial.
 
 ### Basics
@@ -139,7 +139,7 @@ correct formatting. You can fix formatting with `./gradlew spotlessApply`.
 
 - [1]  [https://cwiki.apache.org/confluence/display/GEODE/Criteria+for+Code+Submissions](https://cwiki.apache.org/confluence/display/GEODE/Criteria+for+Code+Submissions)
 - [2]  [https://cwiki.apache.org/confluence/display/GEODE/How+to+Contribute](https://cwiki.apache.org/confluence/display/GEODE/How+to+Contribute)
-- [3]  [http://www.apache.org/licenses/#clas](http://www.apache.org/licenses/#clas)
+- [3]  [https://www.apache.org/licenses/#clas](http://www.apache.org/licenses/#clas)
 
 ## Export Control
 
@@ -150,7 +150,7 @@ of encryption software. BEFORE using any encryption software,
 please check your country's laws, regulations and policies
 concerning the import, possession, or use, and re-export of
 encryption software, to see if this is permitted.
-See <http://www.wassenaar.org/> for more information.
+See <https://www.wassenaar.org/> for more information.
 
 The U.S. Government Department of Commerce, Bureau of Industry and Security (BIS),
 has classified this software as Export Commodity Control Number (ECCN) 5D002.C.1,
@@ -166,7 +166,7 @@ The following provides more details on the included cryptographic software:
 
 * Apache Geode is designed to be used with
   [Java Secure Socket Extension](https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html) (JSSE) and
-  [Java Cryptography Extension](http://docs.oracle.com/javase/8/docs/technotes/guides/security/crypto/CryptoSpec.html) (JCE).
-  The [JCE Unlimited Strength Jurisdiction Policy](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)
+  [Java Cryptography Extension](https://docs.oracle.com/javase/8/docs/technotes/guides/security/crypto/CryptoSpec.html) (JCE).
+  The [JCE Unlimited Strength Jurisdiction Policy](https://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html)
   may need to be installed separately to use keystore passwords with 7 or more characters.
 * Apache Geode links to and uses [OpenSSL](https://www.openssl.org/) ciphers.


### PR DESCRIPTION
**What is this change?**

This change updates the README to point to active links so the image / graphic is displayed. Currently, the image / graphic appear as a broken image.

BEFORE this change (as-is)

![b4](https://user-images.githubusercontent.com/12024098/150069100-fcc87db0-3371-407c-8766-5344a68805ac.png)

AFTER this change is merged (will-be)

![now](https://user-images.githubusercontent.com/12024098/150069120-e9fa3306-6d7f-4acb-b77b-5dcefe41c8e5.png)

**Why is this change necessary?**

Having visible, crisp logos and graphics on the main README give users, consumers, and contributors confidence they are contributing to a project that is polished, maintained and kept in good order.