### PR TITLE
GEODE-10151: Extract redis distribution

### DIFF
--- a/geodeForRedis/build.gradle
+++ b/geodeForRedis/build.gradle
@@ -18,3 +18,19 @@
 dependencies {
     implementation("redis.clients:jedis")
 }
+
+
+task installRedis(type: Copy) {
+    from {
+        zipTree(tarTree(rootProject.configurations.geodeDistribution.singleFile)
+                .matching { include("**/geode-for-redis-*.zip")}.singleFile )
+    }
+    eachFile { fcp ->
+        fcp.path = fcp.path.replaceFirst("^geode-for-redis-[a-zA-Z0-9\\.\\-]+\\/", "geode-for-redis/")
+    }
+
+    into buildDir
+    includeEmptyDirs false
+}
+
+run.dependsOn(installRedis)

--- a/geodeForRedis/scripts/start.gfsh
+++ b/geodeForRedis/scripts/start.gfsh
@@ -15,14 +15,17 @@
 
 start locator --name=locator --bind-address=localhost
 
+set variable --name=STAR --value=*
 start server --name=redisServer1 --locators=localhost[10334] --server-port=0 \
     --J=-Dgemfire.geode-for-redis-enabled=true \
     --J=-Dgemfire.geode-for-redis-port=6379 \
     --J=-Dgemfire.geode-for-redis-bind-address=127.0.0.1 \
-    --J=-Dgemfire.geode-for-redis-redundant-copies=1
+    --J=-Dgemfire.geode-for-redis-redundant-copies=1 \
+    --classpath=../build/geode-for-redis/lib/${STAR}
 
 start server --name=redisServer2 --locators=localhost[10334] --server-port=0 \
     --J=-Dgemfire.geode-for-redis-enabled=true \
     --J=-Dgemfire.geode-for-redis-port=6380 \
     --J=-Dgemfire.geode-for-redis-bind-address=127.0.0.1 \
-    --J=-Dgemfire.geode-for-redis-redundant-copies=1
+    --J=-Dgemfire.geode-for-redis-redundant-copies=1 \
+    --classpath=../build/geode-for-redis/lib/${STAR}


### PR DESCRIPTION
The redis example needs to include the redis distribution on the classpath of
the geode server. Adding support in the build to extract the redis
distribution, and modifying the start scripts for this example to include
geode-for-redis on the classpath.